### PR TITLE
chore: spring-boot-http-gradle to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,4 +18,4 @@ dependencies:
   version: 0.0.1
 - name: spring-boot-http-gradle
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.2


### PR DESCRIPTION
chore: Promote spring-boot-http-gradle to version 0.0.2